### PR TITLE
fix: delegate extensionless files to nextLoad instead of short-circui…

### DIFF
--- a/src/hooks.mts
+++ b/src/hooks.mts
@@ -101,11 +101,7 @@ export const loadSync: LoadHookSync = (url, context, nextLoad) => {
     const { ext } = parse(filename)
     if (!ext) {
       record(url)
-      return {
-        ...context,
-        format: 'commonjs',
-        shortCircuit: true,
-      }
+      return nextLoad(url, { ...context, format: 'commonjs' })
     }
   }
 
@@ -132,11 +128,7 @@ export const load = async (
     // after all.
     if (!ext) {
       record(url)
-      return {
-        ...context,
-        format: 'commonjs',
-        shortCircuit: true,
-      }
+      return await nextLoad(url, { ...context, format: 'commonjs' })
     }
   }
 

--- a/test/hooks.cts
+++ b/test/hooks.cts
@@ -79,3 +79,37 @@ t.test('extensionless does not blow up, it is just cjs', async t => {
     t.equal(result.stdout.toString().trim(), 'hello')
   }
 })
+
+// strict sync load hook path (node >= 24.13 via registerHooks). A
+// short-circuit without `source` throws ERR_INVALID_RETURN_PROPERTY_VALUE
+// there, so the extensionless branch must delegate to nextLoad instead.
+t.test(
+  'extensionless via --import (sync registerHooks) does not blow up',
+  async t => {
+    const importEntry = String(
+      pathToFileURL(resolve(__dirname, '../dist/esm/import.mjs')),
+    )
+    // mirror real usage: a CJS module require()s an extensionless bin
+    // (as package bin scripts are). That path is strict-validated.
+    const dir = t.testdir({
+      bin: `console.log('hello from extensionless bin')`,
+      'runner.cjs': `require('./bin')`,
+    })
+    const result = spawnSync(process.execPath, [
+      '--no-warnings',
+      '--import',
+      importEntry,
+      resolve(dir, 'runner.cjs'),
+    ])
+    t.equal(result.status, 0, result.stderr.toString())
+    t.notMatch(
+      result.stderr.toString(),
+      /ERR_INVALID_RETURN_PROPERTY_VALUE/,
+      'no strict source validation error',
+    )
+    t.equal(
+      result.stdout.toString().trim(),
+      'hello from extensionless bin',
+    )
+  },
+)

--- a/test/hooks.mjs
+++ b/test/hooks.mjs
@@ -113,10 +113,15 @@ t.test('no extension, treat as commonjs', async t => {
   const ctx = {}
   const u = String(pathToFileURL(resolve('/test/extensionless/file')))
   t.equal(typeof globalPreload(), 'string', 'call gp without port')
-  const res = await load(u, ctx, async () => {
-    throw new Error('should not call nextLoad')
+  // must delegate to nextLoad with a commonjs format hint, so node's
+  // default step supplies a valid `source` (strict sync hook validation
+  // on node >= 24.13 rejects a short-circuit with no source).
+  const res = await load(u, ctx, async (url, c) => {
+    t.equal(url, u)
+    t.equal(c.format, 'commonjs', 'forces commonjs format')
+    return { source: mockContent, format: 'commonjs' }
   })
-  t.strictSame(res, { format: 'commonjs', shortCircuit: true })
+  t.strictSame(res, { source: mockContent, format: 'commonjs' })
   t.strictSame(pi.files, [
     fileURLToPath(import.meta.url),
     resolve('/test/extensionless/file'),


### PR DESCRIPTION
This pull request updates the module loader hooks to ensure compatibility with Node.js strict validation (Node >= 24.13), particularly when handling extensionless files. The main change is to delegate extensionless file loading to `nextLoad` with a `commonjs` format hint, instead of short-circuiting, which prevents validation errors. The tests have also been updated and expanded to verify this behavior in both sync and async load hooks.

**Loader hook improvements:**

* Changed the extensionless file handling in both the sync (`loadSync`) and async (`load`) hooks to delegate to `nextLoad` with `{ format: 'commonjs' }` instead of returning a short-circuit result. This avoids `ERR_INVALID_RETURN_PROPERTY_VALUE` errors under Node.js strict validation. [[1]](diffhunk://#diff-ceb721e4f51afba5386ff11d9d33d9bf55ce4fc87e245dc44b5a1e50668a67bdL104-R104) [[2]](diffhunk://#diff-ceb721e4f51afba5386ff11d9d33d9bf55ce4fc87e245dc44b5a1e50668a67bdL135-R131)

**Testing updates:**

* Updated existing tests in `test/hooks.mjs` to expect delegation to `nextLoad` and to validate that the correct format and source are returned for extensionless files.
* Added a new test in `test/hooks.cts` to specifically verify that extensionless files loaded via sync hooks (using `--import`) do not trigger strict validation errors in Node.js >= 24.13.